### PR TITLE
Change: remove token expiration

### DIFF
--- a/api/auth.py
+++ b/api/auth.py
@@ -9,20 +9,17 @@ import json
 def generate_token(obj):
     fernet = Fernet(current_app.config['SECRET_KEY'])
     now = datetime.now().timestamp()
-    expiration = current_app.config.get('TOKEN_EXPIRATION', 43200)  # 12 hours
     data = {
         'issued_at': now,
-        'expiration_date': now + expiration,
         'data': obj
     }
-    return fernet.encrypt(json.dumps(data).encode()), expiration
+    return fernet.encrypt(json.dumps(data).encode())
 
 
 def decrypt_token(token):
     fernet = Fernet(current_app.config['SECRET_KEY'])
-    expiration = current_app.config.get('TOKEN_EXPIRATION', 43200)  # 12 hours
     try:
-        decrypted = fernet.decrypt(token.encode(), expiration)
+        decrypted = fernet.decrypt(token.encode())
     except InvalidToken:
         return None
     return json.loads(decrypted.decode())

--- a/api/routes/auth.py
+++ b/api/routes/auth.py
@@ -24,8 +24,7 @@ def home():
     user = User.query.filter_by(username=username).first()
     if user:
         if user.check_password(password):
-            token, expiration = generate_token({'user_id': user.id})
+            token = generate_token({'user_id': user.id})
             return jsonify(message="Login Successful",
-                           token=token.decode(),
-                           expires_in=expiration)
+                           token=token.decode())
     return jsonify(message="Login Unsuccessful"), 400


### PR DESCRIPTION
Because, we decided to invalidate the token at the end of the festival,
instead of token expiration.